### PR TITLE
Add <code> wrapping button

### DIFF
--- a/src/mini_format_pack/config.json
+++ b/src/mini_format_pack/config.json
@@ -25,7 +25,7 @@
         {
             "name": "formatInlineCode",
             "tooltip": "Insert inline code",
-            "hotkey": "ctrl+shift+.",
+            "hotkey": "ctrl+,",
             "label": "#"
         },
         {

--- a/src/mini_format_pack/config.json
+++ b/src/mini_format_pack/config.json
@@ -23,6 +23,12 @@
             "hotkey": "ctrl+."
         },
         {
+            "name": "formatInlineCode",
+            "tooltip": "Insert inline code",
+            "hotkey": "ctrl+shift+.",
+            "label": "#"
+        },
+        {
             "name": "insertHorizontalRule",
             "tooltip": "Insert horizontal line",
             "hotkey": "ctrl+shift+alt+_"

--- a/src/mini_format_pack/main.py
+++ b/src/mini_format_pack/main.py
@@ -52,6 +52,10 @@ def formatBlockPre(editor):
     editor.web.eval("setFormat('formatBlock', 'pre')")
 
 
+def formatInlineCode(editor):
+    editor.web.eval("wrap('<code>', '</code>')")
+
+
 def insertHorizontalRule(editor):
     editor.web.eval("setFormat('insertHorizontalRule')")
 


### PR DESCRIPTION
Hi!

I'd like to add a button and shortcut to wrap text in `<code>`. Looks like #6 is about requesting inline `<code>`, too.

Unfortunately my implementation does not allow undoing that once it's done.

I've played around a bit with JavaScript to try to remove the the `<code>` tag if it's already present, but it seems to be hard.

Do you think it would be good enough to merge like this, even if it's not undoable (without editing HTML manually)?

#### Description

Add wrappinng of selected text in `<code>`.

My use-case is that I use `<pre>` for longer code samples, but `<code>` for inline code.

I've tested this on the Anki packaged in my Ubuntu installation - 2.1.8.

Unfortunately, there is no `document.execCommand` for adding a `<code>` tag, so I just wrap the selection in `<code>...</code>`. Unfortunately, once you do that, there's no easy way to undo that - both Ctrl+Z and another press of Ctrl+Shift+ will not remove the `<code>...</code>`.

Looking at the source code of the Anki 2.0 addon Power Format Pack (https://gitlab.com/neftas/supplementary-buttons-anki/blob/master/power_format_pack/utility.py#L820), it looks like it is not able to remove the `<code>...</code>` wrapping once inserted, either.

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version:
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
