### PR TITLE
Add button to wrap selected text in an <abbr> tag

### DIFF
--- a/src/mini_format_pack/config.json
+++ b/src/mini_format_pack/config.json
@@ -6,6 +6,12 @@
             "hotkey": "alt+shift+5"
         },
         {
+            "name": "abbr",
+            "tooltip": "Apply &lt;abbr&gt; tag",
+            "hotkey": "ctrl+shift+alt+a",
+            "label": "&lt;abbr&gt;"
+        },
+        {
             "name": "onBackground",
             "tooltip": "Highlight text",
             "hotkey": "ctrl+shift+b",

--- a/src/mini_format_pack/main.py
+++ b/src/mini_format_pack/main.py
@@ -46,11 +46,8 @@ def strikeThrough(editor):
 
 def abbr(editor):
     title = getOnlyText(_("Full text for the abbreviation:"), default="")
-    editor.web.eval("""
-        var sel = document.getSelection().toString();
-        document.execCommand("insertHTML", false,
-                             "<abbr title='{}'>" + sel + "</abbr>");
-    """.format(html.escape(title)))
+    title = html.escape(title)
+    editor.web.eval("""wrap("<abbr title='{}'>", "</abbr>")""".format(title))
 
 
 def indent(editor):

--- a/src/mini_format_pack/main.py
+++ b/src/mini_format_pack/main.py
@@ -12,10 +12,13 @@ License: GNU AGPLv3 <https://www.gnu.org/licenses/agpl.html>
 """
 
 
+import html
+
 from aqt import mw
 from aqt.qt import *
 from aqt.utils import getOnlyText
 from anki.hooks import addHook
+from anki.lang import _
 from anki.utils import isWin, isMac
 
 from .consts import addon_path
@@ -45,8 +48,9 @@ def abbr(editor):
     title = getOnlyText(_("Full text for the abbreviation:"), default="")
     editor.web.eval("""
         var sel = document.getSelection().toString();
-        document.execCommand("insertHTML", false, "<abbr title='{}'>" + sel + "</abbr>");
-    """.format(title))
+        document.execCommand("insertHTML", false,
+                             "<abbr title='{}'>" + sel + "</abbr>");
+    """.format(html.escape(title)))
 
 
 def indent(editor):

--- a/src/mini_format_pack/main.py
+++ b/src/mini_format_pack/main.py
@@ -14,6 +14,7 @@ License: GNU AGPLv3 <https://www.gnu.org/licenses/agpl.html>
 
 from aqt import mw
 from aqt.qt import *
+from aqt.utils import getOnlyText
 from anki.hooks import addHook
 from anki.utils import isWin, isMac
 
@@ -38,6 +39,14 @@ def insertUnorderedList(editor):
 
 def strikeThrough(editor):
     editor.web.eval("setFormat('strikeThrough')")
+
+
+def abbr(editor):
+    title = getOnlyText(_("Full text for the abbreviation:"), default="")
+    editor.web.eval("""
+        var sel = document.getSelection().toString();
+        document.execCommand("insertHTML", false, "<abbr title='{}'>" + sel + "</abbr>");
+    """.format(title))
 
 
 def indent(editor):


### PR DESCRIPTION
### Description

Fixes #11

todo:
- add button icon

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [x] Running Anki 2.1 from source (commit ed8340a)
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bullseye
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
