### PR TITLE
changing insertHorizontalRule hotkey description

### DIFF
--- a/src/mini_format_pack/config.json
+++ b/src/mini_format_pack/config.json
@@ -25,7 +25,7 @@
         {
             "name": "insertHorizontalRule",
             "tooltip": "Insert horizontal line",
-            "hotkey": "ctrl+shift+alt+_"
+            "hotkey": "ctrl+shift+alt+-"
         },
         {
             "name": "insertUnorderedList",


### PR DESCRIPTION
#### Description

The "ctrl+shift+alt+_" hotkey does't work with underscore, but the "ctrl+shift+alt+-" works well.

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [x] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
