### PR TITLE
Extend version parsing to work with Anki's new version scheme

### DIFF
--- a/src/mini_format_pack/consts.py
+++ b/src/mini_format_pack/consts.py
@@ -9,11 +9,14 @@ Copyright: (c) 2018 Glutanimate <https://glutanimate.com/>
 License: GNU AGPLv3 <https://www.gnu.org/licenses/agpl.html>
 """
 
+import re
 import sys
 import os
 from anki import version
 
-anki21 = version.startswith("2.1.")
+version_re = re.compile(r"^(?P<year>\d*)\.(?P<month>\d*)(\.(?P<patch>\d*))?$")
+mo = version_re.search(version)
+anki21 = version.startswith("2.1.") or int(mo.group("year")) >= 23
 sys_encoding = sys.getfilesystemencoding()
 
 if anki21:


### PR DESCRIPTION
#### Description
Match new version naming scheme `year.month.patch`

```
When loading '⁨Mini Format Pack⁩':
⁨Traceback (most recent call last):
  File "aqt.addons", line 239, in loadAddons
  File "C:\Users\mathi\AppData\Roaming\Anki2\addons21\295889520\__init__.py", line 15, in <module>
    from . import main
  File "C:\Users\mathi\AppData\Roaming\Anki2\addons21\295889520\main.py", line 20, in <module>
    from .consts import addon_path
  File "C:\Users\mathi\AppData\Roaming\Anki2\addons21\295889520\consts.py", line 22, in <module>
    addon_path = os.path.dirname(__file__).decode(sys_encoding)
AttributeError: 'str' object has no attribute 'decode'
```

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
  - [x] Anki 23.10 (23823d31)⁩ running from source
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian 12
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
